### PR TITLE
Removed flex from card container which was causing items to overlap

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class CreditCard extends Component {
         super(props);
         this.state = {
             type: {
-                name:"unknown", 
+                name:"unknown",
                 length: 16
             }
         }
@@ -52,7 +52,7 @@ class CreditCard extends Component {
                 return this.setState({type: {name: type, length: 16}});
             }
         }
-        
+
         return this.setState({type: {name: "unknown", length: 16}});
     }
     number() {
@@ -152,7 +152,7 @@ class CreditCard extends Component {
                                  style={styles.logo}
                                  source={{uri: images[this.props.type ? this.props.type : this.state.type.name]}}
                             />
-                            {isAmex ? 
+                            {isAmex ?
                                 <View style={styles.cvcFront}>
                                     <Text style={styles.text}>{this.getValue("cvc")}</Text>
                                 </View>
@@ -195,7 +195,7 @@ const styles = StyleSheet.create({
     container: {
         borderRadius: 8,
         borderWidth: 0,
-        flex: 1,
+        flex: null,
     },
     logo: {
         height: 35,


### PR DESCRIPTION
I was having issues formatting the card. I was only able to fix it by removing the flex from the card container. I was not using any image for the card, so this may have caused the issue. Either way, it works with and without card images now.

Before: This is a flex:1 view with a card inside. No styling is applied to the card.
<img width="382" alt="screen shot 2017-09-11 at 2 47 18 pm" src="https://user-images.githubusercontent.com/25510902/30291384-b883c62c-9700-11e7-8bc6-c4a610ca19eb.png">

After: This is a flex:1 view with a card inside. No styling is applied to the card.
<img width="376" alt="screen shot 2017-09-11 at 2 43 23 pm" src="https://user-images.githubusercontent.com/25510902/30291392-bb246f8a-9700-11e7-8706-6cded2bca0e8.png">
